### PR TITLE
Update fr.po

### DIFF
--- a/src/lang/_strings/fr.po
+++ b/src/lang/_strings/fr.po
@@ -332,7 +332,7 @@ msgstr "Scanner la librairie audio"
 
 msgctxt ""
 msgid "About Chorus"
-msgstr "A propos de Chorus"
+msgstr "À propos de Chorus"
 
 msgctxt ""
 msgid "Recent"
@@ -562,7 +562,7 @@ msgstr "Le contrôle à distance est configuré correctement"
 
 msgctxt ""
 msgid "About"
-msgstr "A propos"
+msgstr "À propos"
 
 msgctxt ""
 msgid "Local audio"


### PR DESCRIPTION
Spelling issue : "A propos" => "À propos" (https://fr.wiktionary.org/wiki/%C3%A0-propos)