### PR TITLE
Fix lots of XSS due to missing escaping of HTML entities (CVE-2018-8831)

### DIFF
--- a/src/js/apps/album/edit/edit_controller.js.coffee
+++ b/src/js/apps/album/edit/edit_controller.js.coffee
@@ -5,7 +5,7 @@
     initialize: ->
       @model = @getOption('model')
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('title')
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('title')
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/album/list/list_view.js.coffee
+++ b/src/js/apps/album/list/list_view.js.coffee
@@ -17,9 +17,7 @@
         @model.set(App.request('album:action:items'))
     setMeta: ->
       if @model
-        artist = if @model.get('artist') != '' then @model.get('artist') else '&nbsp;'
-        artistLink = @themeLink artist, helpers.url.get('artist', @model.get('artistid'))
-        @model.set subtitle: artistLink
+        @model.set subtitleHtml: @themeLink @model.get('artist'), helpers.url.get('artist', @model.get('artistid'))
 
   class List.Empty extends App.Views.EmptyViewResults
     tagName: "li"

--- a/src/js/apps/artist/edit/edit_controller.js.coffee
+++ b/src/js/apps/artist/edit/edit_controller.js.coffee
@@ -5,7 +5,7 @@
     initialize: ->
       @model = @getOption('model')
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('artist')
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('artist')
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/browser/list/list_view.js.coffee
+++ b/src/js/apps/browser/list/list_view.js.coffee
@@ -66,7 +66,11 @@
     tagName: 'li'
     initialize: ->
     # Parse title text
-      @model.set {label: @formatText(@model.get('label'))}
+      @model.set {labelHtml: @formatText(@model.get('label'))}
+      
+    onBeforeRender: ->
+      if !@model.get('labelHtml')
+        @model.set {labelHtml: @model.escape('label')}
 
   class List.Folder extends List.Item
     className: 'folder'

--- a/src/js/apps/browser/list/tpl/file.jst.eco
+++ b/src/js/apps/browser/list/tpl/file.jst.eco
@@ -1,5 +1,5 @@
 <div class="thumb" style="background-image: url('<%= @thumbnail %>')"><div class="mdi play"></div></div>
-<div class="title" title="<%= helpers.global.stripTags(@label) %>"><%- @label %></div>
+<div class="title" title="<%= helpers.global.stripTags(@labelHtml) %>"><%- @labelHtml %></div>
 <ul class="actions">
     <li class="menu dropdown">
         <i data-toggle="dropdown" class="mdi"></i>

--- a/src/js/apps/external/youtube/youtube_controller.js.coffee
+++ b/src/js/apps/external/youtube/youtube_controller.js.coffee
@@ -32,7 +32,7 @@
     API.getSearchView query, 'List', '', {}, (view) ->
       $footer = $('<a>', {class: 'btn btn-primary', href: 'https://www.youtube.com/results?search_query=' + query, target: '_blank'})
       $footer.html('More videos')
-      App.execute "ui:modal:show", query, view.render().$el, $footer
+      App.execute "ui:modal:show", _.escape(query), view.render().$el, $footer
 
   App.commands.setHandler "youtube:list:view", (query, title, options = {}, callback) ->
     API.getSearchView query, 'CardList', title, options, callback

--- a/src/js/apps/external/youtube/youtube_view.js.coffee
+++ b/src/js/apps/external/youtube/youtube_view.js.coffee
@@ -24,7 +24,7 @@
       @getMeta()
     getMeta: ->
       if @model
-        @model.set {subtitle: @themeLink 'YouTube', @model.get('url'), {external: true}}
+        @model.set {subtitleHtml: @themeLink 'YouTube', @model.get('url'), {external: true}}
         if @model.get('addonEnabled')
           @model.set {menu: {localplay: 'Local play'}}
     onRender: () ->

--- a/src/js/apps/filter/show/show_view.js.coffee
+++ b/src/js/apps/filter/show/show_view.js.coffee
@@ -100,7 +100,7 @@
     triggers:
       "click .filterable-remove" : "filter:option:remove"
     initialize: ->
-      tooltip = t.gettext('Remove') + ' ' + @model.get('key') + ' ' + t.gettext('filter')
+      tooltip = t.gettext('Remove') + ' ' + @model.escape('key') + ' ' + t.gettext('filter')
       text = @themeTag('span', {'class': 'text'}, @model.get('values').join(', '))
       tag = @themeTag('span', {'class': 'filter-btn filterable-remove', title: tooltip}, text)
       @model.set(title: tag)
@@ -125,6 +125,6 @@
     className: "filters-active-bar"
     onRender: ->
       if @options.filters
-        $('.filters-active-all', @$el).html( @options.filters.join(', ') )
+        $('.filters-active-all', @$el).text( @options.filters.join(', ') )
     triggers:
       'click .remove': 'filter:remove:all'

--- a/src/js/apps/help/overview/overview_controller.js.coffee
+++ b/src/js/apps/help/overview/overview_controller.js.coffee
@@ -54,20 +54,20 @@
     # Chorus version.
     getReportChorusVersion: ->
       $.get "addon.xml", (data) =>
-	      $('.report-chorus-version > span', @$pageView).html $('addon', data).attr('version')
+	      $('.report-chorus-version > span', @$pageView).text $('addon', data).attr('version')
 
     # Kodi version
     getReportKodiVersion: ->
       state = App.request "state:kodi"
       kodiVersion = state.getState('version')
-      $('.report-kodi-version > span', @$pageView).html kodiVersion.major + '.' + kodiVersion.minor
+      $('.report-kodi-version > span', @$pageView).text kodiVersion.major + '.' + kodiVersion.minor
 
     # Web sockets.
     getReportWebsocketsActive: ->
       wsActive = App.request "sockets:active"
       $ws = $('.report-websockets', @$pageView)
       if wsActive
-        $('span', $ws).html tr("Remote control is set up correctly")
+        $('span', $ws).text tr("Remote control is set up correctly")
         $ws.removeClass 'warning'
       else
         $('span', $ws).html tr("You need to 'Allow remote control' for Kodi. You can do that") + ' <a href="#settings/kodi/services">' + tr('here') + '</a>'
@@ -76,4 +76,4 @@
     # Local audio
     getReportLocalAudio: ->
       localAudio = if soundManager.useHTML5Audio then "HTML 5" else "Flash"
-      $('.report-local-audio > span', @$pageView) .html localAudio
+      $('.report-local-audio > span', @$pageView) .text localAudio

--- a/src/js/apps/input/resume/resume_controller.js.coffee
+++ b/src/js/apps/input/resume/resume_controller.js.coffee
@@ -27,7 +27,7 @@
 				for item in items
 					$el = $('<span>')
 					.attr('data-percent', item.percent)
-					.html(item.title)
+					.text(item.title)
 					.click (e)->
 						# Callback for option click
 						App.execute "command:video:play", model, idKey, $(@).data('percent')

--- a/src/js/apps/lab/lab/lab_view.js.coffee
+++ b/src/js/apps/lab/lab/lab_view.js.coffee
@@ -21,7 +21,7 @@
     className: "lab--items page"
     childView: lab.labItem
     onRender: ->
-      @$el.prepend $('<h3>').html( t.gettext('Experimental code, use at own risk') )
-      @$el.prepend $('<h2>').html( t.gettext('The lab') )
+      @$el.prepend $('<h3>').text( t.gettext('Experimental code, use at own risk') )
+      @$el.prepend $('<h2>').text( t.gettext('The lab') )
       @$el.addClass('page-secondary')
 

--- a/src/js/apps/loading/loading_app.js.coffee
+++ b/src/js/apps/loading/loading_app.js.coffee
@@ -2,14 +2,14 @@
 
   API =
 
-    getLoaderView: (msgText = 'Just a sec...', inline = false) ->
+    getLoaderView: (msgTextHtml = 'Just a sec...', inline = false) ->
       new LoadingApp.Show.Page
-        text: msgText
+        textHtml: msgTextHtml
         # Inline is used when the loader is not full page
         inline: inline
 
-  App.commands.setHandler "loading:show:view", (region, msgText) ->
-    view = API.getLoaderView msgText
+  App.commands.setHandler "loading:show:view", (region, msgTextHtml) ->
+    view = API.getLoaderView msgTextHtml
     region.show view
 
   ## Replace whole page with loader.

--- a/src/js/apps/loading/show/loading_view.js.coffee
+++ b/src/js/apps/loading/show/loading_view.js.coffee
@@ -3,7 +3,7 @@
   class Show.Page extends Backbone.Marionette.ItemView
     template: "apps/loading/show/loading_page"
     onRender: ->
-      @$el.find('h2').html @options.text
+      @$el.find('h2').html @options.textHtml
     attributes: ->
       if @options.inline
         {

--- a/src/js/apps/localPlaylist/list/list_view.js.coffee
+++ b/src/js/apps/localPlaylist/list/list_view.js.coffee
@@ -17,11 +17,9 @@
     tagName: "li"
     initialize: ->
       path = helpers.url.get 'playlist', @model.get('id')
-      classes = []
+      @model.set(title: @model.get('name'), path: path)
       if path is helpers.url.path()
-        classes.push 'active'
-      tag = @themeLink(@model.get('name'), path, {'className': classes.join(' ')})
-      @model.set(title: tag)
+        @model.set(active: true)
 
   class List.Lists extends App.Views.CompositeView
     template: 'apps/localPlaylist/list/playlist_list'
@@ -29,7 +27,7 @@
     tagName: "div"
     childViewContainer: 'ul.lists'
     onRender: ->
-      $('h3', @$el).html( t.gettext('Playlists') )
+      $('h3', @$el).text( t.gettext('Playlists') )
 
   class List.Selection extends App.Views.ItemView
     template: 'apps/localPlaylist/list/playlist'
@@ -46,7 +44,7 @@
     className: 'playlist-selection-list'
     childViewContainer: 'ul.lists'
     onRender: ->
-      $('h3', @$el).html( t.gettext('Existing playlists') )
+      $('h3', @$el).text( t.gettext('Existing playlists') )
 
   class List.Layout extends App.Views.LayoutView
     template: 'apps/localPlaylist/list/playlist_layout'
@@ -63,4 +61,4 @@
       'click .local-playlist-header .export' : 'list:export'
     onRender: ->
       if @options and @options.list
-        $('h2', @$el).html( @options.list.get('name') )
+        $('h2', @$el).text( @options.list.get('name') )

--- a/src/js/apps/localPlaylist/list/tpl/playlist.jst.eco
+++ b/src/js/apps/localPlaylist/list/tpl/playlist.jst.eco
@@ -1,1 +1,9 @@
-<span class="item"><%- @title %></span>
+<span class="item">
+    <% if @path: %>
+        <a href="#<%= @path %>"<% if @active: %> class="active"<% end %>>
+            <%= @title %>
+        </a>
+    <% else: %>
+        <%= @title %>
+    <% end %>
+</span>

--- a/src/js/apps/localPlaylist/localPlaylist_app.js.coffee
+++ b/src/js/apps/localPlaylist/localPlaylist_app.js.coffee
@@ -38,7 +38,7 @@
           collection: playlists
         $content = view.render().$el
         ## New list button
-        $new = $('<button>').html( tr('Create a new list') ).addClass('btn btn-primary')
+        $new = $('<button>').text( tr('Create a new list') ).addClass('btn btn-primary')
         $new.on 'click', =>
           _.defer ->
             API.createNewList(entityType, id)

--- a/src/js/apps/movie/edit/edit_controller.js.coffee
+++ b/src/js/apps/movie/edit/edit_controller.js.coffee
@@ -6,7 +6,7 @@
       @model = @getOption('model')
 
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('title')
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('title')
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/movie/list/list_view.js.coffee
+++ b/src/js/apps/movie/list/list_view.js.coffee
@@ -21,7 +21,7 @@
     setMeta: ->
       if @model
         @model.set
-          subtitle: @themeLink @model.get('year'), 'movies?year=' + @model.get('year')
+          subtitleHtml: @themeLink @model.get('year'), 'movies?year=' + @model.get('year')
 
   class List.Empty extends App.Views.EmptyViewResults
     tagName: "li"

--- a/src/js/apps/movie/show/show_controller.js.coffee
+++ b/src/js/apps/movie/show/show_controller.js.coffee
@@ -75,7 +75,7 @@
       @contentLayout = new Show.Content model: movie
       @listenTo @contentLayout, "movie:youtube", (view) ->
         trailer = movie.get('mediaTrailer')
-        App.execute "ui:modal:youtube", movie.get('title') + ' Trailer', trailer.id
+        App.execute "ui:modal:youtube", movie.escape('title') + ' Trailer', trailer.id
       @listenTo @contentLayout, 'show', =>
         if movie.get('cast').length > 0
           @contentLayout.regionCast.show @getCast(movie)

--- a/src/js/apps/movie/show/show_view.js.coffee
+++ b/src/js/apps/movie/show/show_view.js.coffee
@@ -50,6 +50,6 @@
     className: 'movie-set'
     onRender: ->
       if @options and @options.set
-          $('h2.set-name', @$el).html( @options.set )
+          $('h2.set-name', @$el).text( @options.set )
     regions: ->
       regionCollection: '.collection-items'

--- a/src/js/apps/musicvideo/edit/edit_controller.js.coffee
+++ b/src/js/apps/musicvideo/edit/edit_controller.js.coffee
@@ -5,7 +5,7 @@
     initialize: ->
       @model = @getOption('model')
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('title')
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('title')
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/musicvideo/list/list_view.js.coffee
+++ b/src/js/apps/musicvideo/list/list_view.js.coffee
@@ -18,9 +18,7 @@
         @model.set(App.request('musicvideo:action:items'))
     setMeta: ->
       if @model
-        artist = if @model.get('artist') != '' then @model.get('artist') else '&nbsp;'
-        artistLink = @themeLink artist, 'search/artist/' + artist
-        @model.set subtitle: artistLink
+        @model.set subtitleHtml: @themeLink @model.get('artist'), 'search/artist/' + artist
 
   class List.Empty extends App.Views.EmptyViewResults
     tagName: "li"

--- a/src/js/apps/player/player_app.js.coffee
+++ b/src/js/apps/player/player_app.js.coffee
@@ -114,7 +114,7 @@
       $playerCtx = $('#player-' + player)
       $('.playing-progress', $playerCtx).val(percent)
       $cur = $('.playing-time-current', $playerCtx)
-      $cur.html helpers.global.formatTime(currentTime)
+      $cur.text helpers.global.formatTime(currentTime)
 
     ## Init progress.
     initProgress: (player, percent = 0) ->

--- a/src/js/apps/playlist/list/tpl/playlist_item.jst.eco
+++ b/src/js/apps/playlist/list/tpl/playlist_item.jst.eco
@@ -9,8 +9,8 @@
     </div>
     <div class="meta">
         <div class="title"><a href="#<%= @url %>" title="<%= @label %>"><%= @label %></a></div>
-        <% if @subtitle?: %>
-        <div class="subtitle"><%- @subtitle %></div>
+        <% if @subtitle: %>
+        <div class="subtitle"><%= @subtitle %></div>
         <% end %>
     </div>
     <div class="remove"></div>

--- a/src/js/apps/selected/selected_app.js.coffee
+++ b/src/js/apps/selected/selected_app.js.coffee
@@ -56,7 +56,7 @@
     # Update the count in the selected action area, toggle visibility and and media class
     updateUi: ->
       selectedText = @items.length + ' ' + t.ngettext("item selected", "items selected", @items.length)
-      $('#selected-count').html(selectedText)
+      $('#selected-count').text(selectedText)
       $selectedRegion = $('#selected-region');
       $selectedRegion.removeClassStartsWith('media-');
       $selectedRegion.addClass('media-' + @media)

--- a/src/js/apps/shell/shell_app.js.coffee
+++ b/src/js/apps/shell/shell_app.js.coffee
@@ -91,11 +91,11 @@
 
     ## Set app title.
     setAppTitle: ->
-      App.getRegion('regionTitle').$el.html('')
+      App.getRegion('regionTitle').$el.text('')
       if config.getLocal('showDeviceName', false) is true
         settingsController = App.request "command:kodi:controller", 'auto', 'Settings'
         settingsController.getSettingValue 'services.devicename', (title) ->
-          App.getRegion('regionTitle').$el.html(title)
+          App.getRegion('regionTitle').$el.text(title)
 
     # Shell listeners for context menu.
     bindListenersContextMenu: (shellLayout) ->

--- a/src/js/apps/song/edit/edit_controller.js.coffee
+++ b/src/js/apps/song/edit/edit_controller.js.coffee
@@ -5,7 +5,7 @@
     initialize: ->
       @model = @getOption('model')
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('title')
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('title')
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/state/state_app.js.coffee
+++ b/src/js/apps/state/state_app.js.coffee
@@ -66,12 +66,12 @@
         item = stateObj.getPlaying('item')
         $title.html helpers.entities.playingLink(item)
         $subtitle.html helpers.entities.getSubtitle(item)
-        $dur.html helpers.global.formatTime(stateObj.getPlaying('totaltime'))
+        $dur.text helpers.global.formatTime(stateObj.getPlaying('totaltime'))
         $img.css "background-image", "url('" + item.thumbnail + "')"
       else
         $title.html t.gettext('Nothing playing')
         $subtitle.html ''
-        $dur.html '0'
+        $dur.text '0'
         $img.attr 'src', App.request("images:path:get")
 
 

--- a/src/js/apps/thumbs/list/list_view.js.coffee
+++ b/src/js/apps/thumbs/list/list_view.js.coffee
@@ -18,6 +18,6 @@
     onRender: ->
       if @options
         if @options.entity
-          $('h2.set-header', @$el).html( t.gettext( @options.entity + 's'  ) )
+          $('h2.set-header', @$el).text( t.gettext( @options.entity + 's'  ) )
     regions:
       regionResult: '.set-results'

--- a/src/js/apps/tvshow/editEpisode/edit_episode_controller.js.coffee
+++ b/src/js/apps/tvshow/editEpisode/edit_episode_controller.js.coffee
@@ -5,7 +5,7 @@
     initialize: ->
       @model = @getOption('model')
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('showtitle') + ' - ' + @model.get('title') + ' (S' + @model.get('season') + ' E' + @model.get('episode') + ')'
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('showtitle') + ' - ' + @model.escape('title') + ' (S' + @model.escape('season') + ' E' + @model.escape('episode') + ')'
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/tvshow/editShow/edit_show_controller.js.coffee
+++ b/src/js/apps/tvshow/editShow/edit_show_controller.js.coffee
@@ -5,7 +5,7 @@
     initialize: ->
       @model = @getOption('model')
       options = {
-        title: '<span>' + tr('Edit') + '</span>' + @model.get('title')
+        titleHtml: '<span>' + tr('Edit') + '</span>' + @model.escape('title')
         form: @getStructure()
         formState: @model.attributes
         config:

--- a/src/js/apps/tvshow/episode/episode_view.js.coffee
+++ b/src/js/apps/tvshow/episode/episode_view.js.coffee
@@ -24,7 +24,7 @@
       subTitleTip = if @model.get('firstaired') then {title: tr('First aired') + ': ' + @model.get('firstaired')} else {}
       @model.set
         label: epNum + @model.get('title')
-        subtitle: @themeTag('div', subTitleTip, showLink + epNumFull)
+        subtitleHtml: @themeTag('div', subTitleTip, showLink + epNumFull)
 
 
   class Episode.Empty extends App.Views.EmptyViewResults

--- a/src/js/apps/tvshow/tvshow_app.js.coffee
+++ b/src/js/apps/tvshow/tvshow_app.js.coffee
@@ -45,7 +45,7 @@
         helpers.entities.setProgress($layout, progress)
       # Update the unwatched episodes
       unwatched = parseInt($layout.find('.episode-total').text()) - $layout.find('.region-content .is-watched').length
-      $layout.find('.episode-unwatched').html(unwatched)
+      $layout.find('.episode-unwatched').text(unwatched)
       $layout
 
     getAllEpisodesCollection: (tvshowid, season, callback) ->

--- a/src/js/apps/ui/ui_app.js.coffee
+++ b/src/js/apps/ui/ui_app.js.coffee
@@ -4,7 +4,7 @@
 
   API =
 
-    openModal: (title, msg, open = true, style = '') ->
+    openModal: (titleHtml, msgHtml, open = true, style = '') ->
       ## Get the modal parts
       $title = App.getRegion('regionModalTitle').$el
       $body = App.getRegion('regionModalBody').$el
@@ -12,8 +12,8 @@
       $modal.removeClassStartsWith 'style-'
       $modal.addClass 'style-' + style
       ## Populate its content
-      $title.html(title)
-      $body.html(msg)
+      $title.html(titleHtml)
+      $body.html(msgHtml)
       ## Open model
       if open
         $modal.modal();
@@ -32,7 +32,7 @@
       App.getRegion('regionModalFooter').$el.empty()
 
     getButton: (text, type = 'primary') ->
-      $('<button>').addClass('btn btn-' + type).html(text)
+      $('<button>').addClass('btn btn-' + type).text(text)
 
     defaultButtons: (callback) ->
       $ok = API.getButton(t.gettext('ok'), 'primary').on('click', ->
@@ -69,6 +69,7 @@
     ## Open a options modal.
     ## options is an object with a title and items, items is an array of single objects with
     ## a title and callback key. when the option is clicked the callback is called.
+    ## Options are HTML (must be pre-escaped).
     buildOptions: (options) ->
       if options.length is 0
         return
@@ -84,7 +85,7 @@
       $wrap
 
   ## Open a text input modal window, callback receives the entered text.
-  ## Options properties: {msg: 'string', open: 'bool', defaultVal: 'string'}
+  ## Options properties: {msgHtml: 'string', open: 'bool', defaultVal: 'string'}
   App.commands.setHandler "ui:textinput:show", (title, options = {}, callback) ->
     msg = if options.msg then options.msg else ''
     open = if options.open then true else false
@@ -94,7 +95,7 @@
         callback( $('#text-input').val() )
         API.closeModal()
     )
-    $msg = $('<p>').html(msg)
+    $msg = $('<p>').text(msg)
     API.defaultButtons -> callback $('#text-input').val()
     API.openModal(title, $msg, callback, open)
     el = App.getRegion('regionModalBody').$el.append($input.wrap('<div class="form-control-wrapper"></div>'))
@@ -107,35 +108,35 @@
     API.closeModal()
 
   ## Open a confirm modal
-  App.commands.setHandler "ui:modal:confirm", (title, msg = '', callback) ->
+  App.commands.setHandler "ui:modal:confirm", (titleHtml, msgHtml = '', callback) ->
     API.confirmButtons -> callback true
-    API.openModal(title, msg, true, 'confirm')
+    API.openModal(titleHtml, msgHtml, true, 'confirm')
 
   ## Open a modal window
-  App.commands.setHandler "ui:modal:show", (title, msg = '', footer = '', closeButton = false, style = '') ->
-    API.getModalButtonContainer().html(footer)
+  App.commands.setHandler "ui:modal:show", (titleHtml, msgHtml = '', footerHtml = '', closeButton = false, style = '') ->
+    API.getModalButtonContainer().html(footerHtml)
     if closeButton
       API.getModalButtonContainer().prepend API.closeModalButton()
-    API.openModal(title, msg, true, style)
+    API.openModal(titleHtml, msgHtml, true, style)
 
   ## Open a form modal window
-  App.commands.setHandler "ui:modal:form:show", (title, msg = '', style = 'form') ->
-    API.openModal(title, msg, true, style)
+  App.commands.setHandler "ui:modal:form:show", (titleHtml, msgHtml = '', style = 'form') ->
+    API.openModal(titleHtml, msgHtml, true, style)
 
   ## Close a modal window
   App.commands.setHandler "ui:modal:close", ->
     API.closeModal()
 
   ## Open a youtube video in a modal
-  App.commands.setHandler "ui:modal:youtube", (title, videoid) ->
+  App.commands.setHandler "ui:modal:youtube", (titleHtml, videoid) ->
     API.getModalButtonContainer().html('')
-    msg = '<iframe width="560" height="315" src="https://www.youtube.com/embed/' + videoid + '?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0" allowfullscreen></iframe>'
-    API.openModal(title, msg, true, 'video')
+    msgHtml = '<iframe width="560" height="315" src="https://www.youtube.com/embed/' + videoid + '?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0" allowfullscreen></iframe>'
+    API.openModal(titleHtml, msgHtml, true, 'video')
 
   ## Open an options modal
-  App.commands.setHandler "ui:modal:options", (title, items) ->
+  App.commands.setHandler "ui:modal:options", (titleHtml, items) ->
     $options = API.buildOptions(items)
-    API.openModal(title, $options, true, 'options')
+    API.openModal(titleHtml, $options, true, 'options')
 
   ## Toggle player menu
   App.commands.setHandler "ui:playermenu", (op) ->

--- a/src/js/components/form/form_controller.js.coffee
+++ b/src/js/components/form/form_controller.js.coffee
@@ -56,5 +56,6 @@
     formContent = formController.formLayout.render().$el
     formController.formLayout.trigger 'show'
     popupStyle = if options.config.editForm then 'edit-form' else 'form'
-    App.execute "ui:modal:form:show", options.title, formContent, popupStyle
+    titleHtml = options.titleHtml ? _.escape(options.title)
+    App.execute "ui:modal:form:show", titleHtml, formContent, popupStyle
 

--- a/src/js/components/form/form_view.js.coffee
+++ b/src/js/components/form/form_view.js.coffee
@@ -64,7 +64,7 @@
 
     addSuccessMsg: (msg) ->
       $el = $(".response", @$el)
-      $el.html(msg).show()
+      $el.text(msg).show()
       setTimeout((->
         $el.fadeOut()
       ), 5000)

--- a/src/js/components/form/tpl/form_item.jst.eco
+++ b/src/js/components/form/tpl/form_item.jst.eco
@@ -1,5 +1,5 @@
 <% if @title: %>
-    <label class="control-label"><%- @title %></label>
+    <label class="control-label"><%= @title %></label>
 <% end %>
 
 <% if @type is 'markup': %>

--- a/src/js/components/form/tpl/form_item_group.jst.eco
+++ b/src/js/components/form/tpl/form_item_group.jst.eco
@@ -1,4 +1,4 @@
 <% if @title: %>
-    <h3 class="group-title"><% if @icon: %><i class="<%- @icon %>"></i> <% end %><%- @title %></h3>
+    <h3 class="group-title"><% if @icon: %><i class="<%= @icon %>"></i> <% end %><%= @title %></h3>
 <% end %>
 <div class="form-items"></div>

--- a/src/js/components/form/tpl/form_item_imageselect.jst.eco
+++ b/src/js/components/form/tpl/form_item_imageselect.jst.eco
@@ -14,7 +14,7 @@
         </div>
         <div class="pane" rel="url">
             <% if @title: %>
-            <label class="control-label"><%- @title %></label>
+            <label class="control-label"><%= @title %></label>
             <% end %>
             <div class="form-imageselect__url">
                 <%- @element %>

--- a/src/js/helpers/entities.js.coffee
+++ b/src/js/helpers/entities.js.coffee
@@ -45,7 +45,7 @@ helpers.entities.getSubtitle = (model) ->
 
 ## Basic link to entity
 helpers.entities.playingLink = (model) ->
-  "<a href='##{model.url}'>#{model.label}</a>"
+  "<a href='##{model.url}'>#{_.escape(model.label)}</a>"
 
 ## Is watched
 helpers.entities.isWatched = (model) ->
@@ -91,7 +91,7 @@ helpers.entities.refreshEntity = (model, controller, method, params = {}) ->
   thumbs = Kodi.request "thumbsup:check", model
   params.ignorenfo = config.getLocal 'refreshIgnoreNFO', true
   # Show confirm box
-  Kodi.execute "ui:modal:confirm", tr('Are you sure?'), t.sprintf(tr('Confirm refresh'), title), () ->
+  Kodi.execute "ui:modal:confirm", tr('Are you sure?'), _.escape(t.sprintf(tr('Confirm refresh'), title)), () ->
     # Clear model from cache and remove thumbs up
     Backbone.fetchCache.clearItem(model)
     if thumbs

--- a/src/js/helpers/global.js.coffee
+++ b/src/js/helpers/global.js.coffee
@@ -109,16 +109,17 @@ helpers.global.stringStripStartsWith = (start, data) ->
 ## Turn an array of strings into a collective sentence.
 ## eg. ['foo', 'bar', 'other'] = 'foo, bar and other'
 ## Pluralise = 'foos, bars and others'
+## Returns HTML
 helpers.global.arrayToSentence = (arr, pluralise = true) ->
   str = ''
   prefix = if pluralise then 's' else ''
   last = arr.pop()
   if arr.length > 0
     for i, item of arr
-      str += '<strong>' + item + prefix + '</strong>'
+      str += '<strong>' + _.escape(item + prefix) + '</strong>'
       str += if parseInt(i) isnt (arr.length - 1) then ', ' else ''
     str += ' ' + t.gettext('and') + ' ';
-  str += '<strong>' + last + prefix + '</strong>'
+  str += '<strong>' + _.escape(last + prefix) + '</strong>'
 
 
 # Encode/Decode a string which is typically a file path that we want to use

--- a/src/js/views/_base/view.js.coffee
+++ b/src/js/views/_base/view.js.coffee
@@ -4,7 +4,7 @@
 
   _.extend Marionette.View::,
 
-    # Build a link.
+    # Build a link. Link text gets escaped.
     themeLink: (name, url, options = {}) ->
       _.defaults options,
         external: false,
@@ -21,22 +21,13 @@
       if options.className isnt ''
         attrs.class = options.className
 
-      @themeTag 'a', attrs, name
+      $("<a>").attr(attrs).text(name).wrap('<div/>').parent().html()
 
-    # Parse tag attributes into a string.
-    parseAttributes: (attrs) ->
-      a = []
-      for attr, val of attrs
-        val = String(val).split('"').join('&quot;')
-        a.push attr + '="' + val + '"'
-      a.join(' ')
-
-    # Make a tag
+    # Make a tag. Contents can be HTML (they are not escaped)
     themeTag: (el, attrs, value) ->
-      attrsString = @parseAttributes(attrs)
-      "<#{el} #{attrsString}>#{value}</#{el}>"
+      $("<#{el}>").attr(attrs).html(value).wrap('<div/>').parent().html()
 
-    # Formats dynamic text using filers.
+    # Formats dynamic text using filers. Returns HTML.
     formatText: (text, addInLineBreaks = false) ->
       # Filter via bb code (used in browser folder names)
       res = XBBCODE.process

--- a/src/js/views/card/card_view.js.coffee
+++ b/src/js/views/card/card_view.js.coffee
@@ -24,6 +24,12 @@
         class: classes.join(' ')
       }
 
+    onBeforeRender: ->
+      if !@model.get('labelHtml')?
+        @model.set 'labelHtml', _.escape(@model.get('label'))
+      if !@model.get('subtitleHtml')?
+        @model.set 'subtitleHtml', _.escape(@model.get('subtitle'))
+
     onRender: ->
       @$el.data('model', @model)
 

--- a/src/js/views/card/tpl/card.jst.eco
+++ b/src/js/views/card/tpl/card.jst.eco
@@ -1,15 +1,15 @@
 <div class="card-<%= @type %>">
     <div class="artwork">
-        <a href="#<%= @url %>" class="thumb" title="<%= helpers.global.stripTags(@label) %>" style="background-image: url('<%= @thumbnail %>')"></a>
+        <a href="#<%= @url %>" class="thumb" title="<%= helpers.global.stripTags(@labelHtml) %>" style="background-image: url('<%= @thumbnail %>')"></a>
         <div class="mdi play" title="<%= tr('Play') %>"></div>
         <% if @type is "channeltv" or @type is "channelradio": %>
           <div class="mdi record"></div>
         <% end %>
     </div>
     <div class="meta">
-        <div class="title"><a href="#<%= @url %>" title="<%= helpers.global.stripTags(@label) %>"><%- @label %></a></div>
-        <% if @subtitle?: %>
-            <div class="subtitle"><%- @subtitle %></div>
+        <div class="title"><a href="#<%= @url %>" title="<%= helpers.global.stripTags(@labelHtml) %>"><%- @labelHtml %></a></div>
+        <% if @subtitleHtml: %>
+            <div class="subtitle"><%- @subtitleHtml %></div>
         <% end %>
     </div>
     <% if @actions: %>

--- a/src/js/views/empty/empty_view.js.coffee
+++ b/src/js/views/empty/empty_view.js.coffee
@@ -11,6 +11,6 @@
       regionEmptyContent:  ".empty-result"
     onRender: ->
       if @options and @options.emptyKey
-        $('.empty-key', @$el).html tr(@options.emptyKey)
+        $('.empty-key', @$el).text tr(@options.emptyKey)
       if @options and @options.emptyBackUrl
         $('.back-link', @$el).html @themeLink(tr('Go back'), @options.emptyBackUrl)


### PR DESCRIPTION
This fixes CVE-2018-8831 and lots of similar problems by escaping
in the view as much as possible.

I hope this doesn't break too much really :-/ I've tested some stuff but I'm not a regular user of the webinterface so I'm not sure.
XSS seems to have been overlooked completely so far. This revamps a lot of places to:
* use `.text()` instead of `.html()` where possible
* clearly mark html content as such by naming the variable `...Html`
* use escaping with `<%=` in the view wherever possible
* use `escape()` instead of `get()` for outputting model data when warranted
* create HTML tags with jQuery instead of parsing attributes in a custom fashion