### PR TITLE
[docs] Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,80 @@
+---
+name: Problem report
+about: Create an extensive report to help us document a problem
+
+---
+<!--- Please fill out this template to the best of your ability. You can always edit this issue once you have created it. -->
+<!--- Read the following link before you create a new problem report: https://kodi.wiki/view/HOW-TO:Submit_a_bug_report  -->
+## Bug report
+### Describe the bug
+Here is a clear and concise description of what the problem is:
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+<!--- A bug report that is not clear will be closed -->
+<!--- Put your text below this line -->
+
+
+
+## Expected Behavior
+Here is a clear and concise description of what was expected to happen:
+<!--- Tell us what should happen -->
+<!--- Put your text below this line -->
+
+
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+<!--- Put your text below this line -->
+
+
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+<!--- Put your text below this line -->
+
+
+
+### To Reproduce
+Steps to reproduce the behavior:
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+<!--- Put your text below this line -->
+1. 
+2.
+3.
+
+
+### Debuglog
+<!--- Put your text below this line -->
+<!--- A debuglog is always mandatory when creating an issue. Provide one! -->
+The debuglog can be found here:
+
+
+
+### Screenshots 
+Here are some links or screenshots to help explain the problem:
+<!--- Put your text below this line -->
+
+
+
+## Additional context or screenshots (if appropriate)
+Here is some additional context or explanation that might help:
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+<!--- Put your text below this line -->
+
+
+
+### Your Environment
+Used Operating system:
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+<!--- Put your text below this line. Checkboxes can easily be ticked once issue is created -->
+ - Used browser(s):
+ - Operating system version/name:
+ - Kodi version and platform:
+ - Chorus2 version:
+ 
+
+
+
+<!--- End of this issue -->
+*note: Once the issue is made we require you to update it with new information or Kodi versions should that be required.
+Team Kodi will consider your problem report however, we will not make any promises the problem will be solved.*

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,80 @@
+---
+name: Problem report
+about: Create an extensive report to help us document a problem
+
+---
+<!--- Please fill out this template to the best of your ability. You can always edit this issue once you have created it. -->
+<!--- Read the following link before you create a new problem report: https://kodi.wiki/view/HOW-TO:Submit_a_bug_report  -->
+## Bug report
+### Describe the bug
+Here is a clear and concise description of what the problem is:
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+<!--- A bug report that is not clear will be closed -->
+<!--- Put your text below this line -->
+
+
+
+## Expected Behavior
+Here is a clear and concise description of what was expected to happen:
+<!--- Tell us what should happen -->
+<!--- Put your text below this line -->
+
+
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+<!--- Put your text below this line -->
+
+
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+<!--- Put your text below this line -->
+
+
+
+### To Reproduce
+Steps to reproduce the behavior:
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+<!--- Put your text below this line -->
+1. 
+2.
+3.
+
+
+### Debuglog
+<!--- Put your text below this line -->
+<!--- A debuglog is always mandatory when creating an issue. Provide one! -->
+The debuglog can be found here:
+
+
+
+### Screenshots 
+Here are some links or screenshots to help explain the problem:
+<!--- Put your text below this line -->
+
+
+
+## Additional context or screenshots (if appropriate)
+Here is some additional context or explanation that might help:
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+<!--- Put your text below this line -->
+
+
+
+### Your Environment
+Used Operating system:
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+<!--- Put your text below this line. Checkboxes can easily be ticked once issue is created -->
+ - Used browser(s):
+ - Operating system version/name:
+ - Kodi version and platform:
+ - Chorus2 version:
+ 
+
+
+
+<!--- End of this issue -->
+*note: Once the issue is made we require you to update it with new information or Kodi versions should that be required.
+Team Kodi will consider your problem report however, we will not make any promises the problem will be solved.*

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.md
@@ -1,0 +1,32 @@
+---
+name: Feature suggestion
+about: Create a feature suggestion item
+
+---
+<!--- Please fill out this template to the best of your ability. You can always edit this issue once you have created it. -->
+## Feature suggestion
+**Detailed Description**
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+
+
+### Context
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->
+
+
+
+### Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+
+
+
+### Additional context, screenshots or links
+Here are some relevant links or screenshots:
+<!--- Put your text below this line -->
+
+
+
+
+<!--- End of this issue -->
+*Note: Team Kodi will consider this item however we will not make any promises if it will be included.*

--- a/.github/ISSUE_TEMPLATE/roadmap_item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap_item.md
@@ -1,0 +1,32 @@
+---
+name: Roadmap suggestion
+about: Create a roadmap/todo suggestion item (Team Kodi members only!)
+
+---
+<!--- Please fill out this template to the best of your ability. You can always edit this issue once you have created it. -->
+## Roadmap or todo suggestion
+**Detailed Description**
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+
+
+### Context
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->
+
+
+
+### Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+
+
+
+### Additional context, screenshots or links
+Here are some relevant links or screenshots
+<!--- Put your text below this line -->
+
+
+
+
+<!--- End of this issue -->
+*Note: Team Kodi will consider this item however we will not make any promises if it will be included.*


### PR DESCRIPTION
This adds some issue templates that github can use so users have some guidance on how to fill in the correct information needed.
If user clicks on "new issue"  he is presented with some template options to choose from. After that he can fill in the template.
Sadly Github mobile pages are lacking so we need to add a fallback template which is the same as the big report one.

![image](https://user-images.githubusercontent.com/907436/46915737-ebf92400-cfaf-11e8-9db7-c20995eaa9b2.png)


This needs to be added to the default branch which currently is master.