### PR TITLE
Use new SoundCloud search path

### DIFF
--- a/src/js/apps/addon/soundcloud/addon_soundcloud_app.js.coffee
+++ b/src/js/apps/addon/soundcloud/addon_soundcloud_app.js.coffee
@@ -6,7 +6,7 @@
 
     searchAddon:
       id: @addonId
-      url: 'plugin://plugin.audio.soundcloud/search/query/?q=[QUERY]'
+      url: 'plugin://plugin.audio.soundcloud/search/?query=[QUERY]'
       title: 'SoundCloud'
       media: 'music'
 


### PR DESCRIPTION
The SoundCloud plugin was recently released in version 3 and has a new search URL.

Although I added a URL to support the old search path, the search URL should be updated, because support for the old search path will be removed in the next major release.

On a side note: the search feature doesn't seem to work for me with any plugin in Kodi (version 18.x-2.4.6): `TypeError: setView.regionResult is undefined`

Depends on https://github.com/jaylinski/kodi-addon-soundcloud/pull/18.