### PR TITLE
Added filter by Tag for movies and tvshows

### DIFF
--- a/src/js/apps/filter/filter_app.js.coffee
+++ b/src/js/apps/filter/filter_app.js.coffee
@@ -118,6 +118,13 @@
         filterCallback: 'multiple'
       }
       {
+        alias: 'tag'
+        type: 'array'
+        key: 'tag'
+        sortOrder: 'asc',
+        filterCallback: 'multiple'
+      }
+      {
         alias: 'actor'
         type: 'object'
         property: 'name'

--- a/src/js/apps/movie/list/list_controller.js.coffee
+++ b/src/js/apps/movie/list/list_controller.js.coffee
@@ -56,7 +56,7 @@
     ## See filter_app.js for available options
     getAvailableFilters: ->
       sort: ['title', 'year', 'dateadded', 'rating', 'random']
-      filter: ['year', 'genre', 'writer', 'director', 'cast', 'set', 'unwatched', 'inprogress', 'mpaa', 'studio', 'thumbsUp']
+      filter: ['year', 'genre', 'writer', 'director', 'cast', 'set', 'unwatched', 'inprogress', 'mpaa', 'studio', 'thumbsUp', 'tag']
 
     ## Apply filter view and provide a handler for applying changes
     getFiltersView: (collection) ->

--- a/src/js/apps/tvshow/list/list_controller.js.coffee
+++ b/src/js/apps/tvshow/list/list_controller.js.coffee
@@ -56,7 +56,7 @@
     ## See filter_app.js for available options
     getAvailableFilters: ->
       sort: ['title', 'year', 'dateadded', 'rating', 'random']
-      filter: ['year', 'genre', 'unwatched', 'inprogress', 'cast', 'mpaa', 'studio', 'thumbsUp']
+      filter: ['year', 'genre', 'unwatched', 'inprogress', 'cast', 'mpaa', 'studio', 'thumbsUp', 'tag']
 
     ## Apply filter view and provide a handler for applying changes
     getFiltersView: (collection) ->

--- a/src/js/entities/kodi/movie.js.coffee
+++ b/src/js/entities/kodi/movie.js.coffee
@@ -8,8 +8,8 @@
 
     fields:
       minimal: ['title', 'thumbnail']
-      small: ['playcount', 'lastplayed', 'dateadded', 'resume', 'rating', 'year', 'file', 'genre', 'writer', 'director', 'cast', 'set', 'studio', 'mpaa']
-      full: ['fanart', 'plotoutline', 'imdbnumber', 'runtime', 'streamdetails', 'plot', 'trailer', 'sorttitle', 'originaltitle', 'country', 'tag']
+      small: ['playcount', 'lastplayed', 'dateadded', 'resume', 'rating', 'year', 'file', 'genre', 'writer', 'director', 'cast', 'set', 'studio', 'mpaa', 'tag']
+      full: ['fanart', 'plotoutline', 'imdbnumber', 'runtime', 'streamdetails', 'plot', 'trailer', 'sorttitle', 'originaltitle', 'country']
 
     ## Fetch a single entity
     getEntity: (id, options) ->

--- a/src/js/entities/kodi/tvshow.js.coffee
+++ b/src/js/entities/kodi/tvshow.js.coffee
@@ -8,8 +8,8 @@
 
     fields:
       minimal: ['title']
-      small: ['thumbnail', 'playcount', 'lastplayed', 'dateadded', 'episode', 'rating', 'year', 'file', 'genre', 'watchedepisodes', 'cast', 'studio', 'mpaa']
-      full: ['fanart', 'imdbnumber', 'episodeguide', 'plot', 'tag', 'sorttitle', 'originaltitle', 'premiered', 'art']
+      small: ['thumbnail', 'playcount', 'lastplayed', 'dateadded', 'episode', 'rating', 'year', 'file', 'genre', 'watchedepisodes', 'cast', 'studio', 'mpaa', 'tag']
+      full: ['fanart', 'imdbnumber', 'episodeguide', 'plot', 'sorttitle', 'originaltitle', 'premiered', 'art']
 
     ## Fetch a single entity
     getEntity: (id, options) ->


### PR DESCRIPTION
This was fairly easy to implement given that all the properties already exist for media items. Under 20 lines changed. Adds the filter definition, adds tag to the filter selection in the list controllers, and changes the set property to be pulled on "small" fetch. 

The only thing this is missing is translations for the msgid "tag" which does not exist. It works fine in English, but obviously entries for other languages are missing. 