### PR TITLE
Fix movie, season and show posters/thumbs for kodi 19

### DIFF
--- a/src/js/entities/kodi/_base/models.js.coffee
+++ b/src/js/entities/kodi/_base/models.js.coffee
@@ -46,6 +46,12 @@
           model.start = helpers.global.dateStringToObj(model.starttime)
         if model.endtime
           model.end = helpers.global.dateStringToObj(model.endtime)
+
+        # artwork is in art map since kodi 19. Fallbacks of poster to thumb have been removed
+        if type is 'movie' or type is 'tvshow' or type is 'season'
+          model.fanart = if 'fanart' of model.art then model.art.fanart
+          model.thumbnail = if 'poster' of model.art then model.art.poster else if 'thumb' of model.art then model.art.thumb
+
         if type is 'tvshow' or type is 'season'
           model.progress = helpers.global.round ((model.watchedepisodes / model.episode) * 100), 2
         if type is 'episode' or type is 'movie' and model.progress is 0

--- a/src/js/entities/kodi/movie.js.coffee
+++ b/src/js/entities/kodi/movie.js.coffee
@@ -7,9 +7,9 @@
   API =
 
     fields:
-      minimal: ['title', 'thumbnail']
+      minimal: ['title', 'art']
       small: ['playcount', 'lastplayed', 'dateadded', 'resume', 'rating', 'year', 'file', 'genre', 'writer', 'director', 'cast', 'set', 'studio', 'mpaa']
-      full: ['fanart', 'plotoutline', 'imdbnumber', 'runtime', 'streamdetails', 'plot', 'trailer', 'sorttitle', 'originaltitle', 'country', 'tag']
+      full: ['plotoutline', 'imdbnumber', 'runtime', 'streamdetails', 'plot', 'trailer', 'sorttitle', 'originaltitle', 'country', 'tag']
 
     ## Fetch a single entity
     getEntity: (id, options) ->

--- a/src/js/entities/kodi/season.js.coffee
+++ b/src/js/entities/kodi/season.js.coffee
@@ -7,8 +7,8 @@
   API =
 
     fields:
-      minimal: ['season']
-      small: ['showtitle', 'playcount', 'thumbnail', 'tvshowid', 'episode', 'watchedepisodes', 'fanart']
+      minimal: ['season', 'art']
+      small: ['showtitle', 'playcount', 'thumbnail', 'tvshowid', 'episode', 'watchedepisodes']
       full: []
 
     ## Fetch a single entity, requires a season collection passed.

--- a/src/js/entities/kodi/tvshow.js.coffee
+++ b/src/js/entities/kodi/tvshow.js.coffee
@@ -7,9 +7,9 @@
   API =
 
     fields:
-      minimal: ['title']
-      small: ['thumbnail', 'playcount', 'lastplayed', 'dateadded', 'episode', 'rating', 'year', 'file', 'genre', 'watchedepisodes', 'cast', 'studio', 'mpaa']
-      full: ['fanart', 'imdbnumber', 'episodeguide', 'plot', 'tag', 'sorttitle', 'originaltitle', 'premiered', 'art']
+      minimal: ['title', 'art']
+      small: ['playcount', 'lastplayed', 'dateadded', 'episode', 'rating', 'year', 'file', 'genre', 'watchedepisodes', 'cast', 'studio', 'mpaa']
+      full: ['imdbnumber', 'episodeguide', 'plot', 'tag', 'sorttitle', 'originaltitle', 'premiered']
 
     ## Fetch a single entity
     getEntity: (id, options) ->


### PR DESCRIPTION
https://github.com/xbmc/xbmc/pull/17127 removed the old fallback in which the movie/show/season poster was automatically placed in the CFileItem thumbnail as a fallback.

All item artwork is in the art map, accessed via the art parameter. Consumers of the jsonrpc api should adjust and decide what the meaning of "thumbnail" is. In the case of chorus, the webinterface uses the thumbnail property for all the items. In case of movies/shows/episodes, thumbnail should be the poster first and (if the poster does not exist) the item thumb. 