### PR TITLE
rename xbmc.pvrclient to new kodi.pvrclient

### DIFF
--- a/dist/js/kodi-webinterface.js
+++ b/dist/js/kodi-webinterface.js
@@ -8053,7 +8053,7 @@ this.Kodi.module("AddonApp.Pvr", function(Pvr, App, Backbone, Marionette, $, _) 
   API = {
     isEnabled: function() {
       return App.request("addon:isEnabled", {
-        type: 'xbmc.pvrclient'
+        type: 'kodi.pvrclient'
       });
     }
   };

--- a/src/js/apps/addon/pvr/addons_pvr_ap.js.coffee
+++ b/src/js/apps/addon/pvr/addons_pvr_ap.js.coffee
@@ -3,7 +3,7 @@
   API =
 
     isEnabled: ->
-      App.request "addon:isEnabled", {type: 'xbmc.pvrclient'}
+      App.request "addon:isEnabled", {type: 'kodi.pvrclient'}
 
   ## Is a pvr client enabled (used for menu visibility).
   App.reqres.setHandler "addon:pvr:enabled", ->


### PR DESCRIPTION
This is related to https://github.com/xbmc/xbmc/pull/16485

About the change on "dist/js/kodi-webinterface.js" I'm not sure, is it required or not? Have not done a change here before.