### PR TITLE
Kodi Player.Seek now requires an object with percentage argument

### DIFF
--- a/src/js/apps/command/local/_base/_base.js.coffee
+++ b/src/js/apps/command/local/_base/_base.js.coffee
@@ -153,11 +153,11 @@
           @localStateUpdate()
 
     ## Seek to a percentage in the song
-    localSeek: (percent) ->
+    localSeek: (param) ->
       stateObj = App.request "state:local"
       localPlay = stateObj.getState 'localPlay'
       if localPlay isnt false
-        newPos = (percent / 100) * localPlay.duration
+        newPos = (param.percentage / 100) * localPlay.duration
         sound = soundManager.getSoundById stateObj.getState('currentPlaybackId')
         sound.setPosition newPos
 

--- a/src/js/apps/player/player_app.js.coffee
+++ b/src/js/apps/player/player_app.js.coffee
@@ -65,14 +65,14 @@
         ## Kodi Slider Progress change
         $progress.on 'change', ->
           API.timerStop()
-          API.doCommand player, 'Seek', Math.round(@vGet()), ->
+          API.doCommand player, 'Seek', {percentage: Math.round(@vGet())}, ->
             API.timerStart()
         $progress.on 'slide', ->
           API.timerStop()
       else
         ## Local slider progress change
         $progress.on 'change', ->
-          API.doCommand player, 'Seek', Math.round(@vGet())
+          API.doCommand player, 'Seek', {percentage: Math.round(@vGet())}
 
       ## Slider volume
       $volume = $('.volume', $playerCtx)
@@ -174,4 +174,4 @@
 
     ## Handler for changing the kodi progress.
     App.commands.setHandler 'player:kodi:progress:update', (percent, callback) ->
-      API.doCommand 'kodi', 'Seek', percent, callback
+      API.doCommand 'kodi', 'Seek', {percentage: percent}, callback


### PR DESCRIPTION
Since https://github.com/xbmc/xbmc/commit/3801ec4b07d74c81d830c83c799ae90228c5cf2e the Player.Seek JSON-RPC command in Kodi 19 no longer interprets a single numeric parameter as the percentage to seek to; it requires an object with a member "percentage".

I made an attempt at fixing this, though I've never worked on CoffeeScript before, so this change should be checked carefully by someone more clue-ful. I have tested that this makes seeking by clicking on the progress bar work, when before it didn't work on Kodi 19 Alpha. I've tested that seeking in the local player also works.