### PR TITLE
[movies][tvshow] Fix art map when updating movie/show details

### DIFF
--- a/src/js/apps/movie/edit/edit_controller.js.coffee
+++ b/src/js/apps/movie/edit/edit_controller.js.coffee
@@ -14,6 +14,7 @@
           editForm: true
           tabs: true
           callback: (data, formView) =>
+            @setArt(data)
             @saveCallback(data, formView)
       }
       form = App.request "form:popup:wrapper", options
@@ -87,6 +88,16 @@
           ]
         }
       ]
+
+    ## Properly write the art map
+    setArt: (data) ->
+      art = {}
+      if 'fanart' of data
+        art["fanart"] = data.fanart
+      if 'thumbnail' of data
+        art["poster"] = data.thumbnail
+        delete data.thumbnail
+      data["art"] = art
 
     ## Save the settings to Kodi
     saveCallback: (data, formView) ->

--- a/src/js/apps/tvshow/editShow/edit_show_controller.js.coffee
+++ b/src/js/apps/tvshow/editShow/edit_show_controller.js.coffee
@@ -13,6 +13,7 @@
           editForm: true
           tabs: true
           callback: (data, formView) =>
+            @setArt(data)
             @saveCallback(data, formView)
       }
       form = App.request "form:popup:wrapper", options
@@ -63,6 +64,16 @@
           ]
         }
       ]
+
+    ## Properly write the art map
+    setArt: (data) ->
+      art = {}
+      if 'fanart' of data
+        art["fanart"] = data.fanart
+      if 'thumbnail' of data
+        art["poster"] = data.thumbnail
+        delete data.thumbnail
+      data["art"] = art
 
     ## Save the settings to Kodi
     saveCallback: (data, formView) ->


### PR DESCRIPTION
This fixes updating the posters/fanart for movies and tvshows when using the edit feature in chorus2. This got broken as the art is no longer in the main object but now belongs to the art map of the item.

Fixes https://github.com/xbmc/chorus2/issues/406