### PR TITLE
Fix Spanish translation for Record Label

### DIFF
--- a/src/lang/_strings/es.po
+++ b/src/lang/_strings/es.po
@@ -969,7 +969,7 @@ msgstr "aleatorio"
 
 msgctxt ""
 msgid "label"
-msgstr "etiqueta"
+msgstr "discográfica"
 
 msgctxt ""
 msgid "formed"
@@ -1081,7 +1081,7 @@ msgstr "Descripción"
 
 msgctxt ""
 msgid "Label"
-msgstr "Etiqueta"
+msgstr "Discográfica"
 
 msgctxt ""
 msgid "Year"


### PR DESCRIPTION
This commit fixes the Spanish translation for "label". As I understand it the correct meaning here is "Record label", whether the previous Spanish translation was using the meaning of "tag".