### PR TITLE
Use subtitleHtml to prevent escaping anchor tag in Artist albums view

### DIFF
--- a/src/js/apps/album/show/show_view.js.coffee
+++ b/src/js/apps/album/show/show_view.js.coffee
@@ -39,7 +39,7 @@
       @model.set(App.request('album:action:items'))
     setMeta: ->
       @model.set
-        subtitle: @themeLink @model.get('year'), 'music/albums?year=' + @model.get('year')
+        subtitleHtml: @themeLink @model.get('year'), 'music/albums?year=' + @model.get('year')
     attributes: ->
       @watchedAttributes 'card-minimal'
 


### PR DESCRIPTION
See HTML artifacts in displaying album year #395
