### PR TITLE
Fix zh_tw

### DIFF
--- a/src/lang/_strings/zh_tw.po
+++ b/src/lang/_strings/zh_tw.po
@@ -1453,4 +1453,4 @@ msgstr "The Movie DB"
 
 msgctxt ""
 msgid "FanartTV"
-msgstr "FanartTV
+msgstr "FanartTV"


### PR DESCRIPTION
This fixes a missing `"` in zh_tw language file.