### PR TITLE
Add missing keybinds in Help > Keyboard (Mute and OSD)

### DIFF
--- a/src/lang/de/keybind-readme.md
+++ b/src/lang/de/keybind-readme.md
@@ -18,11 +18,13 @@ LEERTASTE = Abspielen/Pause
 Taste "C" = Kontextmenü
 Taste "+" = Lauter
 Taste "-" = Leiser
+Taste "M" = Stummschalten
 Taste "X" = Stopp
 Taste "T" = Untertitel umschalten
 Taste ">" = Nächster
 Taste "<" = Vorheriger
 Taste "\" = Vollbild
+Taste "O" = Bildschirmanzeige
 ```
 
 [Verbesserungsverschläge? Klicke hier.](https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee)

--- a/src/lang/en/keybind-readme.md
+++ b/src/lang/en/keybind-readme.md
@@ -20,11 +20,13 @@ SPACE BAR = Play/Pause
 Key "C" = Context menu
 Key "+" = Volume Up
 Key "-" = Volume Down
+Key "M" = Mute
 Key "X" = Stop
 Key "T" = Toggle subtitles
 Key ">" = Play Next
 Key "<" = Play Prev
 Key "\" = Full screen
+Key "O" = On-Screen Display
 ```
 
 [Got improvements to add? click here](https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee)

--- a/src/lang/fr/keybind-readme.md
+++ b/src/lang/fr/keybind-readme.md
@@ -20,11 +20,13 @@ BARRE ESPACE = Jouer/Pause
 Touche "C" = Menu contextuel
 Touche "+" = Agumenter le volume
 Touche "-" = Baisser le volume
+Touche "M" = Assourdir
 Touche "X" = Arrêter
 Touche "T" = Activer/désactiver les sous-titres
 Touche ">" = Jouer le prochain
 Touche "<" = Jouer le précédent
 Touche "\" = Plein écran
+Touche "O" = Affichage à l'écran
 ```
 
 [Des améliorations à rajouter? cliquez ici](https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee)

--- a/src/lang/nl/keybind-readme.md
+++ b/src/lang/nl/keybind-readme.md
@@ -18,11 +18,13 @@ SPATIE BALK = Play/Pauze
 Toets "C" = Context menu
 Toets "+" = Volume Omhoog
 Toets "-" = Volume Omlaag
+Toets "M" = Dempen
 Toets "X" = Stop
 Toets "T" = Schakel Ondertitels
 Toets ">" = Play Volgende
 Toets "<" = Play Vorige
 Toets "\" = Volledig scherm
+Toets "O" = Schermweergave
 ```
 
 [Wil u verbeteringen aanbrengen? klik hier](https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee)

--- a/src/lang/pl/keybind-readme.md
+++ b/src/lang/pl/keybind-readme.md
@@ -21,11 +21,13 @@ SPACJA = Odtwarzaj/Wstrzymaj
 Klawisz "C" = Menu kontekstowe
 Klawisz "+" = Zwiększ głośność
 Klawisz "-" = Zmiejsz głośność
+Klawisz "M" = Wyciszać
 Klawisz "X" = Zatrzymaj
 Klawisz "T" = Przełącz napisy
 Klawisz ">" = Odtwarzaj następne
 Klawisz "<" = Odtwarzaj poprzednie
 Klawisz "\" = Pełen ekran
+Klawisz "O" = Wyświetlacz ekranowy
 ```
 
 [Dysponujesz poprawką? Naciśnij tutaj](https://github.com/xbmc/chorus2/blob/master/src/js/apps/input/input_app.js.coffee)


### PR DESCRIPTION
Adds the "O" (OSD) and "M" (Mute) keybinds to the keyboard help section.

I edited all existing language files even though I only really know english; for the other ones I used online translators so the strings may be slightly off.

Pinging some translators to confirm the strings I added (hope that's okay):
@driet, @jairbubbles, @KasperZutterman, @Etharr
