### PR TITLE
added: aspectRatio helper which converts the stream.aspect into a textual version

### DIFF
--- a/src/js/helpers/streams.js.coffee
+++ b/src/js/helpers/streams.js.coffee
@@ -90,6 +90,36 @@ helpers.stream.langMap =
   Formatters.
 ###
 
+## Textual representation of aspect ratio
+helpers.stream.aspectRatio = (rawAspect) ->
+  if (rawAspect < 1.3499)
+    return '1.33:1'
+
+  if (rawAspect < 1.5080)
+	return '1.37:1'
+
+  if (rawAspect < 1.719)
+	return '1.66:1'
+
+  if (rawAspect < 1.8147)
+	return '16:9'
+
+  if (rawAspect < 2.0174)
+	return '1.85:1'
+
+  if (rawAspect < 2.2738)
+	return '2.20:1'
+
+  if (rawAspect < 2.3749)
+	return '2.35:1'
+
+  if (rawAspect < 2.4739)
+	return '2.40:1'
+
+  if (rawAspect < 2.6529)
+    return '2.55:1'
+
+  return 'Unknown Aspect Ratio'
 
 ## Format an array of video streams.
 helpers.stream.videoFormat = (videoStreams) ->
@@ -97,7 +127,7 @@ helpers.stream.videoFormat = (videoStreams) ->
     match = {label: 'SD'}
     if stream.height and stream.height > 0
        match = _.find( helpers.stream.videoSizeMap, (res) -> (if res.min < stream.height <= res.max then true else false) )
-    videoStreams[i].label = stream.codec + ' ' + match.label + ' (' + stream.width + ' x ' + stream.height + ')'
+    videoStreams[i].label = stream.codec + ' ' + match.label + ' (' + stream.width + ' x ' + stream.height + ') [' + helpers.stream.aspectRatio(stream.aspect) + ']'
     videoStreams[i].shortlabel = stream.codec + ' ' + match.label
     videoStreams[i].res = match.label
   videoStreams
@@ -117,7 +147,7 @@ helpers.stream.audioFormat = (audioStreams) ->
     ch = _.findWhere helpers.stream.audioChannelMap, {channels: stream.channels}
     ch = if ch then ch.label else stream.channels
     lang = ''
-    if stream.language isnt ''
+    if stream.language isnt '' and stream.language isnt 'und'
       lang = ' (' + helpers.stream.formatLanguage(stream.language) + ')'
     audioStreams[i].label = stream.codec + ' ' + ch + lang
     audioStreams[i].shortlabel = stream.codec + ' ' + ch


### PR DESCRIPTION
changed: do not show 'UNKNOWN' next to the audio data when the language is 'und' (unknown) as this is not helpful nor does it make any visual sense.