### PR TITLE
fixed: background path was invalid for html5 streamed content fixes #446

### DIFF
--- a/dist/videoPlayer.html
+++ b/dist/videoPlayer.html
@@ -21,7 +21,7 @@
         }
         function getBaseURL() {
             var parts = window.location.href.split('videoPlayer.html');
-            return parts[0];
+            return parts[0].replace(/\/\s*$/, '');
         }
 
         // Vars.
@@ -50,7 +50,7 @@
                 });
                 $player.append($('<source>', {
                     "type": 'video/mp4',
-                    "src": getBaseURL() + src
+                    "src": getBaseURL() + '/' + src
                 }));
                 $player.attr('width', width).attr('height', height);
             }


### PR DESCRIPTION
window.location.href part[0] can return a trailing / which causes the URI to be invalid for the background poster, modified the code to remove it if it exists then explicitly restore it where required in the video src path