### PR TITLE
fixed: movie titles with escaped characters were showing as escaped in the title. fixes #470

### DIFF
--- a/src/js/apps/movie/list/list_view.js.coffee
+++ b/src/js/apps/movie/list/list_view.js.coffee
@@ -21,6 +21,7 @@
     setMeta: ->
       if @model
         @model.set
+          labelHtml: @model.get('label')
           subtitleHtml: @themeLink @model.get('year'), 'movies?year=' + @model.get('year')
 
   class List.Empty extends App.Views.EmptyViewResults


### PR DESCRIPTION
by default label is converted to labelHtml if labelHtml is undefined, however it will escape it by default.

Explicitly setting labelHtml will bypass the default behaviour and result in the correct rendering